### PR TITLE
Included a small script to process the JSON output and provide an CPU table with info for backend, main-thread, and background workers

### DIFF
--- a/scripts/process_json_create_cpu_secs_table.py
+++ b/scripts/process_json_create_cpu_secs_table.py
@@ -12,6 +12,12 @@ ai_queue_CPU_bthread_n1_used_cpu_total_start = None
 ai_self_used_cpu_sys_start = None
 ai_self_used_cpu_user_start = None
 
+print(
+    "Warning! This script was created to easily understand the first CPU bottleneck among main thread, BG thread, or backend.",
+)
+print(
+    "Currently it only collects up to 1 background worker thread CPU usage. If your setup has more than one BG worker thread please adjust this script accordingly.",
+)
 with open(sys.argv[1]) as json_file:
     dd = json.load(json_file)
     server_stats = dd["ServerRunTimeStats"]
@@ -31,18 +37,24 @@ with open(sys.argv[1]) as json_file:
         ai_queue_CPU_bthread_n1_used_cpu_total = 0
         ai_self_used_cpu_sys = 0
         ai_self_used_cpu_user = 0
-        for hostname, tich_stat in host_stats.items():
+        for hostname, timeframe_server_runtime_stats_dict in host_stats.items():
             ai_main_thread_used_cpu_sys += float(
-                tich_stat["ai_main_thread_used_cpu_sys"]
+                timeframe_server_runtime_stats_dict["ai_main_thread_used_cpu_sys"]
             )
             ai_main_thread_used_cpu_user += float(
-                tich_stat["ai_main_thread_used_cpu_user"]
+                timeframe_server_runtime_stats_dict["ai_main_thread_used_cpu_user"]
             )
             ai_queue_CPU_bthread_n1_used_cpu_total += float(
-                tich_stat["ai_queue_CPU_bthread_n1_used_cpu_total"]
+                timeframe_server_runtime_stats_dict[
+                    "ai_queue_CPU_bthread_n1_used_cpu_total"
+                ]
             )
-            ai_self_used_cpu_sys += float(tich_stat["ai_self_used_cpu_sys"])
-            ai_self_used_cpu_user += float(tich_stat["ai_self_used_cpu_user"])
+            ai_self_used_cpu_sys += float(
+                timeframe_server_runtime_stats_dict["ai_self_used_cpu_sys"]
+            )
+            ai_self_used_cpu_user += float(
+                timeframe_server_runtime_stats_dict["ai_self_used_cpu_user"]
+            )
 
         if ai_main_thread_used_cpu_sys_start is not None:
             ai_main_thread_used_cpu_sys_end = ai_main_thread_used_cpu_sys
@@ -54,8 +66,6 @@ with open(sys.argv[1]) as json_file:
             ai_self_used_cpu_user_end = ai_self_used_cpu_user
 
             timeframe = (float(ts) - float(start_ts)) / 1000000000.0
-            # if timeframe > 0.0:
-            # print(timeframe)
             ai_main_thread_used_cpu_sys_pct = (
                 (ai_main_thread_used_cpu_sys_end - ai_main_thread_used_cpu_sys_start)
                 / timeframe

--- a/scripts/process_json_create_cpu_secs_table.py
+++ b/scripts/process_json_create_cpu_secs_table.py
@@ -1,0 +1,115 @@
+import json
+import sys
+import os
+
+start_ts = None
+end_ts = None
+
+# start
+ai_main_thread_used_cpu_sys_start = None
+ai_main_thread_used_cpu_user_start = None
+ai_queue_CPU_bthread_n1_used_cpu_total_start = None
+ai_self_used_cpu_sys_start = None
+ai_self_used_cpu_user_start = None
+
+with open(sys.argv[1]) as json_file:
+    dd = json.load(json_file)
+    server_stats = dd["ServerRunTimeStats"]
+    print(
+        "{},{},{},{},{}".format(
+            "timeframe",
+            "total_pct [0,#CORES]",
+            "main_thread_pct [0,100]",
+            "background thread [0,100]",
+            "backend_pct",
+        )
+    )
+
+    for ts, host_stats in server_stats.items():
+        ai_main_thread_used_cpu_sys = 0
+        ai_main_thread_used_cpu_user = 0
+        ai_queue_CPU_bthread_n1_used_cpu_total = 0
+        ai_self_used_cpu_sys = 0
+        ai_self_used_cpu_user = 0
+        for hostname, tich_stat in host_stats.items():
+            ai_main_thread_used_cpu_sys += float(
+                tich_stat["ai_main_thread_used_cpu_sys"]
+            )
+            ai_main_thread_used_cpu_user += float(
+                tich_stat["ai_main_thread_used_cpu_user"]
+            )
+            ai_queue_CPU_bthread_n1_used_cpu_total += float(
+                tich_stat["ai_queue_CPU_bthread_n1_used_cpu_total"]
+            )
+            ai_self_used_cpu_sys += float(tich_stat["ai_self_used_cpu_sys"])
+            ai_self_used_cpu_user += float(tich_stat["ai_self_used_cpu_user"])
+
+        if ai_main_thread_used_cpu_sys_start is not None:
+            ai_main_thread_used_cpu_sys_end = ai_main_thread_used_cpu_sys
+            ai_main_thread_used_cpu_user_end = ai_main_thread_used_cpu_user
+            ai_queue_CPU_bthread_n1_used_cpu_total_end = (
+                ai_queue_CPU_bthread_n1_used_cpu_total
+            )
+            ai_self_used_cpu_sys_end = ai_self_used_cpu_sys
+            ai_self_used_cpu_user_end = ai_self_used_cpu_user
+
+            timeframe = (float(ts) - float(start_ts)) / 1000000000.0
+            # if timeframe > 0.0:
+            # print(timeframe)
+            ai_main_thread_used_cpu_sys_pct = (
+                (ai_main_thread_used_cpu_sys_end - ai_main_thread_used_cpu_sys_start)
+                / timeframe
+                * 100.0
+            )
+            ai_main_thread_used_cpu_user_pct = (
+                (ai_main_thread_used_cpu_user_end - ai_main_thread_used_cpu_user_start)
+                / timeframe
+                * 100.0
+            )
+            main_thread_pct = (
+                ai_main_thread_used_cpu_sys_pct + ai_main_thread_used_cpu_user_pct
+            )
+            ai_queue_CPU_bthread_n1_used_cpu_total_pct = (
+                (
+                    ai_queue_CPU_bthread_n1_used_cpu_total_end
+                    - ai_queue_CPU_bthread_n1_used_cpu_total_start
+                )
+                / timeframe
+                * 100.0
+            )
+            ai_self_used_cpu_sys_pct = (
+                (ai_self_used_cpu_sys_end - ai_self_used_cpu_sys_start)
+                / timeframe
+                * 100.0
+            )
+            ai_self_used_cpu_user_pct = (
+                (ai_self_used_cpu_user_end - ai_self_used_cpu_user_start)
+                / timeframe
+                * 100.0
+            )
+            backends_used_cpu_user_pct = (
+                ai_self_used_cpu_user_pct - ai_main_thread_used_cpu_user_pct
+            )
+            backends_used_cpu_sys_pct = (
+                ai_self_used_cpu_sys_pct - ai_main_thread_used_cpu_sys_pct
+            )
+            backend_pct = backends_used_cpu_user_pct + backends_used_cpu_sys_pct
+            total_pct = ai_self_used_cpu_sys_pct + ai_self_used_cpu_user_pct
+            print(
+                "{},{},{},{},{}".format(
+                    timeframe,
+                    total_pct,
+                    main_thread_pct,
+                    ai_queue_CPU_bthread_n1_used_cpu_total_pct,
+                    backend_pct,
+                )
+            )
+
+        ai_main_thread_used_cpu_sys_start = ai_main_thread_used_cpu_sys
+        ai_main_thread_used_cpu_user_start = ai_main_thread_used_cpu_user
+        ai_queue_CPU_bthread_n1_used_cpu_total_start = (
+            ai_queue_CPU_bthread_n1_used_cpu_total
+        )
+        ai_self_used_cpu_sys_start = ai_self_used_cpu_sys
+        ai_self_used_cpu_user_start = ai_self_used_cpu_user
+        start_ts = ts

--- a/scripts/process_json_create_cpu_secs_table.py
+++ b/scripts/process_json_create_cpu_secs_table.py
@@ -1,6 +1,5 @@
 import json
 import sys
-import os
 
 start_ts = None
 end_ts = None


### PR DESCRIPTION
Sample output:
```
~/go/src/github.com/RedisAI/aibench$ python3 scripts/process_json_create_cpu_secs_table.py results/JSON_redisai__cpu_run_1_workers_10_autobatching_0_tensorbatchsize_1_rate_0.json 
Warning! This script was created to easily understand the first CPU bottleneck among main thread, BG thread, or backend.
Currently it only collects up to 1 background worker thread CPU usage. If your setup has more than one BG worker thread please adjust this script accordingly.
timeframe,total_pct [0,#CORES],main_thread_pct [0,100],background thread [0,100],backend_pct
0.999819008,514.59573771176,14.505225329742872,0.7476353160111164,500.0905123820171
1.000034816,511.0073087695378,11.024716163482054,0.5950792817197205,499.9825926060558
0.999990784,451.76326345023574,-48.24134459223177,0.6106056273414672,500.00460804246757
0.999939584,436.6483805485594,36.624212688433786,0.5790349829775278,400.0241678601256
1.000048896,360.91365276603415,-39.0667897902464,0.4839763354931063,399.98044255628054
0.999985664,494.26028571545623,94.25455123324649,0.6820097772921611,400.0057344822098
(...)
```